### PR TITLE
fix: `delegate_attribute` defined in a subclass had an unintended side effect on the superclass.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [Unreleased]
 
+- fix: `delegate_attribute` defined in a subclass had an unintended side effect on the superclass.
 - support ruby 3.4.x
 - refactor: remove some `steep:ignore` by private rbs.
 - refactor: place definitions that you don't want to be used much in private rbs.

--- a/lib/active_record_compose/delegate_attribute.rb
+++ b/lib/active_record_compose/delegate_attribute.rb
@@ -53,8 +53,7 @@ module ActiveRecordCompose
         end
 
         delegate(*delegates, to:, allow_nil:, private:) # steep:ignore
-        delegated_attributes = (self.delegated_attributes ||= []) # steep:ignore
-        attributes.each { delegated_attributes.push(_1.to_s) }
+        self.delegated_attributes = delegated_attributes.to_a + attributes.map { _1.to_s } # steep:ignore
       end
     end
 

--- a/test/active_record_compose/delegate_attribute_test.rb
+++ b/test/active_record_compose/delegate_attribute_test.rb
@@ -40,4 +40,20 @@ class ActiveRecordCompose::InnerModelTest < ActiveSupport::TestCase
 
     assert_equal object.attributes, { 'x' => 'foo', 'y' => 'bar' }
   end
+
+  test 'attributes to be transferred must be independent, even if there is an inheritance relationship' do
+    data = Struct.new(:x, :y, :z, keyword_init: true).new
+    data.x = 'foo'
+    data.y = 'bar'
+    data.z = 'baz'
+
+    o1 = Dummy.new(data)
+    assert_equal o1.attributes, { 'x' => 'foo', 'y' => 'bar' }
+
+    subclass = Class.new(Dummy) do
+      delegate_attribute :z, to: :data
+    end
+    o2 = subclass.new(data)
+    assert_equal o2.attributes, { 'x' => 'foo', 'y' => 'bar', 'z' => 'baz' }
+  end
 end


### PR DESCRIPTION
…e effect on the superclass.