### PR TITLE
avoid twice validation. As a side effect, save must accept argument `…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+- avoid twice validation. As a side effect, save must accept argument `#save(**options)`
+
 ## [0.9.0] - 2025-03-16
 
 - removed `persisted_flag_callback_control` support.

--- a/lib/active_record_compose/wrapped_model.rb
+++ b/lib/active_record_compose/wrapped_model.rb
@@ -70,7 +70,7 @@ module ActiveRecordCompose
         m.destroy
       else
         # @type var m: ActiveRecordCompose::_ARLike
-        m.save
+        m.save(validate: false)
       end
     end
 
@@ -87,7 +87,7 @@ module ActiveRecordCompose
         m.destroy!
       else
         # @type var model: ActiveRecordCompose::_ARLike
-        m.save!
+        m.save!(validate: false)
       end
     end
 

--- a/sig/active_record_compose.rbs
+++ b/sig/active_record_compose.rbs
@@ -5,8 +5,8 @@ module ActiveRecordCompose
   VERSION: String
 
   interface _ARLike
-    def save: -> bool
-    def save!: -> untyped
+    def save: (**untyped options) -> bool
+    def save!: (**untyped options) -> untyped
     def invalid?: -> bool
     def valid?: -> bool
     def errors: -> untyped
@@ -14,8 +14,8 @@ module ActiveRecordCompose
     def ==: (untyped) -> bool
   end
   interface _ARLikeWithDestroy
-    def save: -> bool
-    def save!: -> untyped
+    def save: (**untyped options) -> bool
+    def save!: (**untyped options) -> untyped
     def destroy: -> bool
     def destroy!: -> untyped
     def invalid?: -> bool
@@ -75,8 +75,8 @@ module ActiveRecordCompose
     def self.with_connection: [T] () { () -> T } -> T
 
     def initialize: (?Hash[attribute_name, untyped]) -> void
-    def save: -> bool
-    def save!: -> untyped
+    def save: (**untyped options) -> bool
+    def save!: (**untyped options) -> untyped
     def create: (?Hash[attribute_name, untyped]) -> bool
     def create!: (?Hash[attribute_name, untyped]) -> untyped
     def update: (?Hash[attribute_name, untyped]) -> bool
@@ -89,6 +89,7 @@ module ActiveRecordCompose
     def callback_context: -> (:create | :update)
     def validate_models: -> void
     def save_models: (bang: bool) -> bool
+    def perform_validations: (**untyped options) -> bool
     def raise_validation_error: -> bot
     def raise_on_save_error: -> bot
     def raise_on_save_error_message: -> String

--- a/test/active_record_compose/model_twice_validation_test.rb
+++ b/test/active_record_compose/model_twice_validation_test.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require 'active_record_compose/model'
+
+class ActiveRecordCompose::ModelTwiceValidationTest < ActiveSupport::TestCase
+  class FailureOnTwiceValidation < ActiveRecordCompose::Model
+    def initialize(model = nil)
+      super()
+      models.push(model)
+      @validation_count = 0
+    end
+
+    before_validation :increment_validation_count
+
+    validates :validation_count, numericality: { less_than_or_equal_to: 1 }
+
+    private
+
+    attr_reader :validation_count
+
+    def increment_validation_count
+      @validation_count += 1
+    end
+  end
+
+  test 'FailureOnTwiceValidation model cannot be validated more than once.' do
+    model = FailureOnTwiceValidation.new
+    assert model.valid?
+    assert_not model.valid?
+    assert_not model.valid?
+  end
+
+  test 'Validation must be performed only once for the encompassing model.' do
+    inner_model = FailureOnTwiceValidation.new
+    model = FailureOnTwiceValidation.new(inner_model)
+
+    assert model.save
+  end
+end


### PR DESCRIPTION
…**options`

The change from `#save()` to `#save(**options)` was made to conform to the definitions in many modules of the activerecord.


closes #17