### PR TITLE
fix: Because `define_attribute_methods` was not executed, `#attribute…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+- fix: Because `define_attribute_methods` was not executed, `#attributes` was evaluated each time `attribute?` was called.
+
 ## [0.11.0] - 2025-05-30
 
 - `#attribute_names` now takes into account attributes declared in `.delegate_attribute`

--- a/lib/active_record_compose/delegate_attribute.rb
+++ b/lib/active_record_compose/delegate_attribute.rb
@@ -54,6 +54,7 @@ module ActiveRecordCompose
         end
 
         delegate(*delegates, to:, allow_nil:)
+        attributes.each { define_attribute_methods _1 }
         self.delegated_attributes = delegated_attributes.to_a + attributes.map { _1.to_s }
       end
     end

--- a/sig/_internal/package_private.rbs
+++ b/sig/_internal/package_private.rbs
@@ -42,6 +42,8 @@ module ActiveRecordCompose
     def delegated_attributes: () -> Array[String]
 
     module ClassMethods : Module
+      include ActiveModel::AttributeMethods::ClassMethods
+
       def delegate_attribute: (*untyped methods, to: untyped, ?allow_nil: untyped?) -> untyped
       def delegated_attributes: () -> Array[String]
       def delegated_attributes=: (Array[String]) -> untyped


### PR DESCRIPTION
…s` was evaluated each time `attribute?` was called.