### PR TITLE
Omits default arguments for `#update` and `#update!`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+- Omits default arguments for `#update` and `#update!`. It's to align I/F with ActiveRecord.
+  - `#update(attributes = {})` to `#update(attributes)`
+  - `#update!(attributes = {})` to `#update!(attributes)`
+
 ## [0.11.3] - 2025-07-13
 
 - refactor: Aggregation attribute module.

--- a/lib/active_record_compose/persistence.rb
+++ b/lib/active_record_compose/persistence.rb
@@ -51,7 +51,7 @@ module ActiveRecordCompose
     # Assign attributes and save.
     #
     # @return [Boolean] returns true on success, false on failure.
-    def update(attributes = {})
+    def update(attributes)
       with_transaction_returning_status do
         assign_attributes(attributes)
         save
@@ -60,7 +60,7 @@ module ActiveRecordCompose
 
     # Behavior is same to `#update`, but raises an exception prematurely on failure.
     #
-    def update!(attributes = {})
+    def update!(attributes)
       with_transaction_returning_status do
         assign_attributes(attributes)
         save!

--- a/sig/_internal/package_private.rbs
+++ b/sig/_internal/package_private.rbs
@@ -108,8 +108,8 @@ module ActiveRecordCompose
 
     def save: (**untyped options) -> bool
     def save!: (**untyped options) -> untyped
-    def update: (?Hash[attribute_name, untyped]) -> bool
-    def update!: (?Hash[attribute_name, untyped]) -> untyped
+    def update: (Hash[attribute_name, untyped]) -> bool
+    def update!: (Hash[attribute_name, untyped]) -> untyped
 
     private
     def models: -> ComposedCollection

--- a/sig/active_record_compose.rbs
+++ b/sig/active_record_compose.rbs
@@ -79,8 +79,8 @@ module ActiveRecordCompose
     def initialize: (?Hash[attribute_name, untyped]) -> void
     def save: (**untyped options) -> bool
     def save!: (**untyped options) -> untyped
-    def update: (?Hash[attribute_name, untyped]) -> bool
-    def update!: (?Hash[attribute_name, untyped]) -> untyped
+    def update: (Hash[attribute_name, untyped]) -> bool
+    def update!: (Hash[attribute_name, untyped]) -> untyped
     def id: -> untyped
 
     private

--- a/test/active_record_compose/model_callback_order_test.rb
+++ b/test/active_record_compose/model_callback_order_test.rb
@@ -66,7 +66,7 @@ class ActiveRecordCompose::ModelCallbackOrderTest < ActiveSupport::TestCase
     tracer = []
     model = CallbackOrder.new(tracer, persisted: true)
 
-    model.update
+    model.update({})
     expected =
       [
         "before_save called",
@@ -83,7 +83,7 @@ class ActiveRecordCompose::ModelCallbackOrderTest < ActiveSupport::TestCase
     tracer = []
     model = CallbackOrder.new(tracer, persisted: false)
 
-    model.update
+    model.update({})
     expected =
       [
         "before_save called",


### PR DESCRIPTION
 It's to align I/F with ActiveRecord.