### PR TITLE
Remove `before_commit` callback on test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## [Unreleased]
 
+- Remove `before_commit` callback on test.
+  Although the `before_commit` callback exists internally and actually works, it is an
+  undocumented definition not described in the ActiveRecord documentation. Accordingly,
+  we will not verify this in the callback tests. Also, this callback may stop working in
+  the future.
+  (https://github.com/hamajyotan/active_record_compose/pull/37)
+
 ## [1.0.0] - 2025-09-23
 
 - drop support rails 7.0.x

--- a/test/active_record_compose/model_callback_order_test.rb
+++ b/test/active_record_compose/model_callback_order_test.rb
@@ -14,7 +14,6 @@ class ActiveRecordCompose::ModelCallbackOrderTest < ActiveSupport::TestCase
     before_save { tracer << "before_save called" }
     before_create { tracer << "before_create called" }
     before_update { tracer << "before_update called" }
-    before_commit { tracer << "before_commit called" }
     after_save { tracer << "after_save called" }
     after_create { tracer << "after_create called" }
     after_update { tracer << "after_update called" }
@@ -39,7 +38,6 @@ class ActiveRecordCompose::ModelCallbackOrderTest < ActiveSupport::TestCase
         "before_update called",
         "after_update called",
         "after_save called",
-        "before_commit called",
         "after_commit called"
       ]
     assert { tracer == expected }
@@ -56,7 +54,6 @@ class ActiveRecordCompose::ModelCallbackOrderTest < ActiveSupport::TestCase
         "before_create called",
         "after_create called",
         "after_save called",
-        "before_commit called",
         "after_commit called"
       ]
     assert { tracer == expected }
@@ -73,7 +70,6 @@ class ActiveRecordCompose::ModelCallbackOrderTest < ActiveSupport::TestCase
         "before_update called",
         "after_update called",
         "after_save called",
-        "before_commit called",
         "after_commit called"
       ]
     assert { tracer == expected }
@@ -90,7 +86,6 @@ class ActiveRecordCompose::ModelCallbackOrderTest < ActiveSupport::TestCase
         "before_create called",
         "after_create called",
         "after_save called",
-        "before_commit called",
         "after_commit called"
       ]
     assert { tracer == expected }
@@ -120,7 +115,6 @@ class ActiveRecordCompose::ModelCallbackOrderTest < ActiveSupport::TestCase
         "after_save called",
         "inner transsaction ends",
         "outer transsaction ends",
-        "before_commit called",
         "after_commit called"
       ]
     assert { tracer == expected }


### PR DESCRIPTION
Although the before_commit callback exists internally and actually works, it is an undocumented definition not described in the ActiveRecord documentation. Accordingly, we will not verify this in the callback tests. Also, this callback may stop working in the future.

[3.2. Updating an Object](https://guides.rubyonrails.org/active_record_callbacks.html#updating-an-object)
> Update callbacks are triggered whenever an **existing** record is persisted (i.e. "saved") to the underlying database. They are called before, after and around the object is updated.
> * before_validation
> * after_validation
> * before_save
> * around_save
> * before_update
> * around_update
> * after_update
> * after_save
> * after_commit / after_rollback

`before_commit` is set to `:nodoc:`
https://github.com/rails/rails/blob/v8.0.3/activerecord/lib/active_record/transactions.rb#L248-L251