### PR TITLE
Revert "Remove `before_commit` callback on test"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,5 @@
 ## [Unreleased]
 
-- Remove `before_commit` callback on test.
-  Although the `before_commit` callback exists internally and actually works, it is an
-  undocumented definition not described in the ActiveRecord documentation. Accordingly,
-  we will not verify this in the callback tests. Also, this callback may stop working in
-  the future.
-  (https://github.com/hamajyotan/active_record_compose/pull/37)
-
 ## [1.0.0] - 2025-09-23
 
 - drop support rails 7.0.x

--- a/test/active_record_compose/model_callback_order_test.rb
+++ b/test/active_record_compose/model_callback_order_test.rb
@@ -14,6 +14,7 @@ class ActiveRecordCompose::ModelCallbackOrderTest < ActiveSupport::TestCase
     before_save { tracer << "before_save called" }
     before_create { tracer << "before_create called" }
     before_update { tracer << "before_update called" }
+    before_commit { tracer << "before_commit called" }
     after_save { tracer << "after_save called" }
     after_create { tracer << "after_create called" }
     after_update { tracer << "after_update called" }
@@ -38,6 +39,7 @@ class ActiveRecordCompose::ModelCallbackOrderTest < ActiveSupport::TestCase
         "before_update called",
         "after_update called",
         "after_save called",
+        "before_commit called",
         "after_commit called"
       ]
     assert { tracer == expected }
@@ -54,6 +56,7 @@ class ActiveRecordCompose::ModelCallbackOrderTest < ActiveSupport::TestCase
         "before_create called",
         "after_create called",
         "after_save called",
+        "before_commit called",
         "after_commit called"
       ]
     assert { tracer == expected }
@@ -70,6 +73,7 @@ class ActiveRecordCompose::ModelCallbackOrderTest < ActiveSupport::TestCase
         "before_update called",
         "after_update called",
         "after_save called",
+        "before_commit called",
         "after_commit called"
       ]
     assert { tracer == expected }
@@ -86,6 +90,7 @@ class ActiveRecordCompose::ModelCallbackOrderTest < ActiveSupport::TestCase
         "before_create called",
         "after_create called",
         "after_save called",
+        "before_commit called",
         "after_commit called"
       ]
     assert { tracer == expected }
@@ -115,6 +120,7 @@ class ActiveRecordCompose::ModelCallbackOrderTest < ActiveSupport::TestCase
         "after_save called",
         "inner transsaction ends",
         "outer transsaction ends",
+        "before_commit called",
         "after_commit called"
       ]
     assert { tracer == expected }


### PR DESCRIPTION
Reverts hamajyotan/active_record_compose#37

After careful consideration, we decided to leave the tests as they were.
* It would be useful to have them when we organize the ActiveRecord::Transactions module in the future.
* ActiveRecord guarantees that tests for before_commit are supported.