### PR TITLE
remove TransactionSupport#composite_primary_key?

### DIFF
--- a/lib/active_record_compose/transaction_support.rb
+++ b/lib/active_record_compose/transaction_support.rb
@@ -20,8 +20,6 @@ module ActiveRecordCompose
       # In ActiveRecord, it is soft deprecated.
       delegate :connection, to: :ar_class
 
-      def composite_primary_key? = false # steep:ignore
-
       private
 
       def ar_class = ActiveRecord::Base


### PR DESCRIPTION
There was a dependency on `composite_primary_key?` in the `ActiveRecord::Transactions` module, so I defined it, but I redefined the dependent definition restore_transaction_record_state as a blank operation, so there was no dependency on it.