### PR TITLE
Move `#id` method definition

### DIFF
--- a/lib/active_record_compose/model.rb
+++ b/lib/active_record_compose/model.rb
@@ -359,6 +359,29 @@ module ActiveRecordCompose
       super
     end
 
+    # Returns the ID value. This value is used when passing it to the `:model` option of `form_with`, etc.
+    # Normally it returns nil, but it can be overridden to delegate to the containing model.
+    #
+    # @example Redefine the id method by delegating to the containing model
+    #     class Foo < ActiveRecordCompose::Model
+    #       def initialize(primary_model)
+    #         @primary_model = primary_model
+    #         # ...
+    #       end
+    #
+    #       def id
+    #         primary_model.id
+    #       end
+    #
+    #       private
+    #
+    #       attr_reader :primary_model
+    #     end
+    #
+    # @return [Object] ID value
+    #
+    def id = nil
+
     private
 
     # Returns a collection of model elements to encapsulate.

--- a/lib/active_record_compose/transaction_support.rb
+++ b/lib/active_record_compose/transaction_support.rb
@@ -25,8 +25,6 @@ module ActiveRecordCompose
       def ar_class = ActiveRecord::Base
     end
 
-    def id = nil
-
     def trigger_transactional_callbacks? = true
     def restore_transaction_record_state(_force_restore_state = false) = nil
   end


### PR DESCRIPTION
The definition of #id is moved to ActiveRecordCompose::Model, assuming that it will be accessed from outside, not for internal implementation purposes.