### PR TITLE
Since `#id` is moved to ActiveRecordCompose::Model, rbs also needs to be made public.

### DIFF
--- a/sig/_internal/package_private.rbs
+++ b/sig/_internal/package_private.rbs
@@ -101,8 +101,6 @@ module ActiveRecordCompose
     extend ActiveSupport::Concern
     include ActiveRecord::Transactions
 
-    def id: -> untyped
-
     module ClassMethods
       def connection: -> ActiveRecord::ConnectionAdapters::AbstractAdapter
       def lease_connection: -> ActiveRecord::ConnectionAdapters::AbstractAdapter

--- a/sig/active_record_compose.rbs
+++ b/sig/active_record_compose.rbs
@@ -82,6 +82,8 @@ module ActiveRecordCompose
     def update: (Hash[attribute_name, untyped]) -> bool
     def update!: (Hash[attribute_name, untyped]) -> untyped
 
+    def id: -> untyped
+
     private
     def models: -> ComposedCollection
   end


### PR DESCRIPTION
refs #40

