### PR TITLE
Remove AR::Transactions dependency

### DIFF
--- a/lib/active_record_compose/transaction_support.rb
+++ b/lib/active_record_compose/transaction_support.rb
@@ -1,17 +1,14 @@
 # frozen_string_literal: true
 
+require "active_support/core_ext/module"
+
 module ActiveRecordCompose
   # @private
   module TransactionSupport
     extend ActiveSupport::Concern
-    include ActiveRecord::Transactions
 
     included do
-      # ActiveRecord::Transactions is defined so that methods such as save,
-      # destroy and touch are wrapped with_transaction_returning_status.
-      # However, ActiveRecordCompose::Model does not support destroy and touch, and
-      # we want to keep these operations as undefined behavior, so we remove the definition here.
-      undef_method :destroy, :touch
+      define_callbacks :commit, :rollback, :before_commit, scope: [ :kind, :name ]
     end
 
     module ClassMethods
@@ -20,12 +17,99 @@ module ActiveRecordCompose
       # In ActiveRecord, it is soft deprecated.
       delegate :connection, to: :ar_class
 
+      def before_commit(*args, &block)
+        set_options_for_callbacks!(args)
+        set_callback(:before_commit, :before, *args, &block) # steep:ignore
+      end
+
+      def after_commit(*args, &block)
+        set_options_for_callbacks!(args, prepend_option)
+        set_callback(:commit, :after, *args, &block) # steep:ignore
+      end
+
+      def after_rollback(*args, &block)
+        set_options_for_callbacks!(args, prepend_option)
+        set_callback(:rollback, :after, *args, &block) # steep:ignore
+      end
+
       private
 
       def ar_class = ActiveRecord::Base
+
+      def prepend_option
+        if ActiveRecord.run_after_transaction_callbacks_in_order_defined # steep:ignore
+          { prepend: true }
+        else
+          {}
+        end
+      end
+
+      def set_options_for_callbacks!(args, enforced_options = {})
+        options = args.extract_options!.merge!(enforced_options)
+        args << options
+      end
     end
 
-    def trigger_transactional_callbacks? = true
-    def restore_transaction_record_state(_force_restore_state = false) = nil
+    def save(**options) = with_transaction_returning_status { super }
+
+    def save!(**options) = with_transaction_returning_status { super }
+
+    concerning :SupportForActiveRecordConnectionAdaptersTransaction do
+      def trigger_transactional_callbacks? = true
+
+      def before_committed!
+        _run_before_commit_callbacks
+      end
+
+      def committed!(should_run_callbacks: true)
+        _run_commit_callbacks if should_run_callbacks
+      end
+
+      def rolledback!(force_restore_state: false, should_run_callbacks: true)
+        _run_rollback_callbacks if should_run_callbacks
+      end
+    end
+
+    private
+
+    def with_transaction_returning_status
+      connection_pool.with_connection do |connection|
+        with_pool_transaction_isolation_level(connection) do
+          ensure_finalize = !connection.transaction_open?
+
+          connection.transaction do
+            connection.add_transaction_record(self, ensure_finalize || has_transactional_callbacks?) # steep:ignore
+
+            yield.tap { raise ActiveRecord::Rollback unless _1 }
+          end
+        end
+      end
+    end
+
+    def default_ar_class = ActiveRecord::Base
+
+    def connection_pool(ar_class: default_ar_class)
+      connection_specification_name = ar_class.connection_specification_name
+      role = ar_class.current_role
+      shard = ar_class.current_shard # steep:ignore
+      connection_handler = ar_class.connection_handler # steep:ignore
+      retrieve_options = { role:, shard: }
+      retrieve_options[:strict] = true if ActiveRecord.gem_version.release >= Gem::Version.new("7.2.0")
+
+      connection_handler.retrieve_connection_pool(connection_specification_name, **retrieve_options)
+    end
+
+    def with_pool_transaction_isolation_level(connection, &block)
+      if ActiveRecord.gem_version.release >= Gem::Version.new("8.1.0")
+        isolation_level = ActiveRecord.default_transaction_isolation_level # steep:ignore
+        connection.pool.with_pool_transaction_isolation_level(isolation_level, connection.transaction_open?, &block)
+      else
+        block.call
+      end
+    end
+
+    def has_transactional_callbacks?
+      _rollback_callbacks.present? || _commit_callbacks.present? || _before_commit_callbacks.present? # steep:ignore
+    end
   end
 end

--- a/sig/_internal/package_private.rbs
+++ b/sig/_internal/package_private.rbs
@@ -100,15 +100,35 @@ module ActiveRecordCompose
   module TransactionSupport
     extend ActiveSupport::Concern
     include ActiveRecord::Transactions
+    extend TransactionSupport::ClassMethods
 
     module ClassMethods
+      include ActiveSupport::Callbacks::ClassMethods
+
       def connection: -> ActiveRecord::ConnectionAdapters::AbstractAdapter
       def lease_connection: -> ActiveRecord::ConnectionAdapters::AbstractAdapter
-      def with_connection: [T] () { () -> T } -> T
+      def with_connection: [T] () { (ActiveRecord::ConnectionAdapters::AbstractAdapter) -> T } -> T
+
+      def before_commit: (*untyped) -> untyped
+      def after_commit: (*untyped) -> untyped
+      def after_rollback: (*untyped) -> untyped
 
       private
       def ar_class: -> singleton(ActiveRecord::Base)
+      def prepend_option: -> ({ prepend: true } | {})
+      def set_options_for_callbacks!: (untyped, ?({ prepend: true } | {})) -> untyped
     end
+
+    def save: (**untyped options) -> bool
+    def save!: (**untyped options) -> untyped
+    def _run_before_commit_callbacks: () -> untyped
+    def _run_commit_callbacks: () -> untyped
+    def _run_rollback_callbacks: () -> untyped
+
+    private
+    def default_ar_class: -> singleton(ActiveRecord::Base)
+    def connection_pool: (?ar_class: singleton(ActiveRecord::Base)) -> ActiveRecord::ConnectionAdapters::ConnectionPool
+    def with_pool_transaction_isolation_level: [T] (ActiveRecord::ConnectionAdapters::AbstractAdapter) { () -> T } -> T
   end
 
   module Persistence


### PR DESCRIPTION
The implementation of database transactions has been restructured to avoid dependency on the ActiveRecord::Transaction module and is now entirely controlled by the ActiveRecordCompose::TransactionSupprot module.
As a side effect of this, the previously implicit
`model.is_a?(ActiveRecord::Transaction)` condition no longer holds.