### PR TITLE
Implemented ActiveRecord-like #inspect

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,16 +10,20 @@ ar_version = ENV.fetch("AR", "latest")
 case ar_version
 when "latest"
   gem "activerecord"
+  gem "railties"
 when "head"
   gem "activemodel", github: "rails/rails"
   gem "activerecord", github: "rails/rails"
   gem "activesupport", github: "rails/rails"
+  gem "railties", github: "rails/rails"
 when /-stable\z/
   gem "activemodel", github: "rails/rails", branch: ar_version
   gem "activerecord", github: "rails/rails", branch: ar_version
   gem "activesupport", github: "rails/rails", branch: ar_version
+  gem "railties", github: "rails/rails", branch: ar_version
 else
   gem "activerecord", ar_version
+  gem "railties", ar_version
 end
 
 gem "sqlite3", "~> 2.1"

--- a/lib/active_record_compose.rb
+++ b/lib/active_record_compose.rb
@@ -11,3 +11,5 @@ require_relative "active_record_compose/model"
 #
 module ActiveRecordCompose
 end
+
+require "active_record_compose/railtie" if defined?(::Rails::Railtie)

--- a/lib/active_record_compose/inspectable.rb
+++ b/lib/active_record_compose/inspectable.rb
@@ -1,0 +1,144 @@
+# frozen_string_literal: true
+
+require "active_support/parameter_filter"
+require_relative "attributes"
+
+module ActiveRecordCompose
+  # @private
+  #
+  # It provides #inspect behavior.
+  # It tries to replicate the inspect format provided by ActiveRecord as closely as possible.
+  #
+  # @example
+  #   class Model < ActiveRecordCompose::Model
+  #     def initialize(ar_model)
+  #       @ar_model = ar_model
+  #       super
+  #     end
+  #
+  #     attribute :foo, :date, default: -> { Date.today }
+  #     delegate_attribute :bar, to: :ar_model
+  #
+  #     private attr_reader :ar_model
+  #   end
+  #
+  #   m = Model.new(ar_model)
+  #   m.inspect  #=> #<Model:0x00007ff0fe75fe58 foo: "2025-11-14", bar: "bar">
+  #
+  # @example
+  #   class Model < ActiveRecordCompose::Model
+  #     self.filter_attributes += %i[foo]
+  #
+  #     # ...
+  #   end
+  #
+  #   m = Model.new(ar_model)
+  #   m.inspect  #=> #<Model:0x00007ff0fe75fe58 foo: [FILTERED], bar: "bar">
+  #
+  module Inspectable
+    extend ActiveSupport::Concern
+    include ActiveRecordCompose::Attributes
+
+    included do
+      self.filter_attributes = []
+    end
+
+    module ClassMethods
+      def filter_attributes
+        if @filter_attributes.nil?
+          superclass.filter_attributes # steep:ignore
+        else
+          @filter_attributes
+        end
+      end
+
+      def filter_attributes=(value)
+        @inspection_filter = nil
+        @filter_attributes = value
+      end
+
+      # steep:ignore:start
+
+      def inspection_filter
+        if @filter_attributes.nil?
+          superclass.inspection_filter
+        else
+          @inspection_filter ||= ActiveSupport::ParameterFilter.new(filter_attributes, mask: FILTERED_MASK)
+        end
+      end
+
+      private
+
+      def inherited(subclass)
+        super
+
+        subclass.class_eval do
+          @inspection_filter = nil
+          @filter_attributes ||= nil
+        end
+      end
+
+      FILTERED_MASK =
+        Class.new(DelegateClass(::String)) do
+          def pretty_print(pp)
+            pp.text __getobj__
+          end
+        end.new(ActiveSupport::ParameterFilter::FILTERED).freeze
+      private_constant :FILTERED_MASK
+
+      # steep:ignore:end
+    end
+
+    # Returns a formatted string representation of the record's attributes.
+    #
+    def inspect
+      inspection =
+        if @attributes
+          attributes.map { |k, v| "#{k}: #{format_for_inspect(k, v)}" }.join(", ")
+        else
+          "not initialized"
+        end
+
+      "#<#{self.class} #{inspection}>"
+    end
+
+    # It takes a PP and pretty prints that record.
+    #
+    def pretty_print(pp)
+      pp.object_address_group(self) do
+        if @attributes
+          attrs = attributes
+          pp.seplist(attrs.keys, proc { pp.text "," }) do |attr|
+            pp.breakable " "
+            pp.group(1) do
+              pp.text attr
+              pp.text ":"
+              pp.breakable
+              pp.text format_for_inspect(attr, attrs[attr])
+            end
+          end
+        else
+          pp.breakable " "
+          pp.text "not initialized"
+        end
+      end
+    end
+
+    private
+
+    def format_for_inspect(name, value)
+      return value.inspect if value.nil?
+
+      inspected_value =
+        if value.is_a?(String) && value.length > 50
+          "#{value[0, 50]}...".inspect
+        elsif value.is_a?(Date) || value.is_a?(Time)
+          %("#{value.to_fs(:inspect)}")
+        else
+          value.inspect
+        end
+
+      self.class.inspection_filter.filter_param(name, inspected_value)
+    end
+  end
+end

--- a/lib/active_record_compose/model.rb
+++ b/lib/active_record_compose/model.rb
@@ -2,6 +2,7 @@
 
 require_relative "attributes"
 require_relative "composed_collection"
+require_relative "inspectable"
 require_relative "persistence"
 require_relative "transaction_support"
 require_relative "validations"
@@ -86,6 +87,7 @@ module ActiveRecordCompose
     include ActiveRecordCompose::Persistence
     include ActiveRecordCompose::Validations
     include ActiveRecordCompose::TransactionSupport
+    include ActiveRecordCompose::Inspectable
 
     begin
       # @group Model Core
@@ -351,9 +353,50 @@ module ActiveRecordCompose
       #   Registers a block to be called after the transaction is rolled back.
 
       # @endgroup
-    end
 
-    # @group Model Core
+      # @!method inspect
+      #   Returns a formatted string representation of the record's attributes.
+      #   It tries to replicate the inspect format provided by ActiveRecord as closely as possible.
+      #
+      #   @example
+      #     class Model < ActiveRecordCompose::Model
+      #       def initialize(ar_model)
+      #         @ar_model = ar_model
+      #         super
+      #       end
+      #
+      #       attribute :foo, :date, default: -> { Date.today }
+      #       delegate_attribute :bar, to: :ar_model
+      #
+      #       private attr_reader :ar_model
+      #     end
+      #
+      #     m = Model.new(ar_model)
+      #     m.inspect  #=> #<Model:0x00007ff0fe75fe58 foo: "2025-11-14", bar: "bar">
+      #
+      #   @example use {.filter_attributes}
+      #     class Model < ActiveRecordCompose::Model
+      #       self.filter_attributes += %i[foo]
+      #
+      #       # ...
+      #     end
+      #
+      #     m = Model.new(ar_model)
+      #     m.inspect  #=> #<Model:0x00007ff0fe75fe58 foo: [FILTERED], bar: "bar">
+      #
+      #   @return [String] formatted string representation of the record's attributes.
+      #   @see .filter_attributes
+
+      # @!method self.filter_attributes
+      #   Returns columns not to expose when invoking {#inspect}.
+      #   @return [Array<Symbol>]
+      #   @see #inspect
+
+      # @!method self.filter_attributes=(value)
+      #   Specify columns not to expose when invoking {#inspect}.
+      #   @param [Array<Symbol>] value
+      #   @see #inspect
+    end
 
     def initialize(attributes = {})
       super
@@ -381,6 +424,8 @@ module ActiveRecordCompose
     # @return [Object] ID value
     #
     def id = nil
+
+    # @group Model Core
 
     private
 

--- a/lib/active_record_compose/model.rb
+++ b/lib/active_record_compose/model.rb
@@ -282,7 +282,7 @@ module ActiveRecordCompose
       #   The need for such a value indicates that operations from multiple contexts are being processed.
       #   If the contexts differ, we recommend separating them into different model definitions.
       #
-      #   @params [Hash] Optional parameters.
+      #   @param options [Hash] parameters.
       #   @option options [Boolean] :validate Whether to run validations.
       #     This option is intended for internal use only.
       #     Users should avoid explicitly passing <tt>validate: false</tt>,

--- a/lib/active_record_compose/railtie.rb
+++ b/lib/active_record_compose/railtie.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "rails"
+require "active_record_compose"
+require "active_record/railtie"
+
+module ActiveRecordCompose
+  class Railtie < Rails::Railtie
+    initializer "active_record_compose.set_filter_attributes", after: "active_record.set_filter_attributes" do
+      ActiveSupport.on_load(:active_record) do
+        ActiveRecordCompose::Model.filter_attributes += ActiveRecord::Base.filter_attributes
+      end
+    end
+  end
+end

--- a/sig/_internal/package_private.rbs
+++ b/sig/_internal/package_private.rbs
@@ -6,6 +6,8 @@ module ActiveRecordCompose
 
     def delegated_attributes: () -> Array[Delegation]
 
+    @attributes: untyped
+
     module ClassMethods : Module
       include ActiveModel::Attributes::ClassMethods
       include ActiveModel::AttributeMethods::ClassMethods
@@ -81,6 +83,29 @@ module ActiveRecordCompose
     end
 
     include PackagePrivate
+  end
+
+  module Inspectable
+    extend ActiveSupport::Concern
+    include Attributes
+    extend Inspectable::ClassMethods
+
+    def inspect: () -> String
+    def pretty_print: (untyped q) -> void
+
+    private
+    def format_for_inspect: (String name, untyped value) -> String
+
+    module ClassMethods
+      FILTERED_MASK: String
+
+      def inspection_filter: () -> ActiveSupport::ParameterFilter
+      def filter_attributes: () -> Array[untyped]
+      def filter_attributes=: (Array[untyped]) -> void
+
+      @inspection_filter: ActiveSupport::ParameterFilter?
+      @filter_attributes: untyped
+    end
   end
 
   class Model

--- a/sig/_internal/package_private.rbs
+++ b/sig/_internal/package_private.rbs
@@ -153,6 +153,10 @@ module ActiveRecordCompose
     def raise_on_save_error_message: -> String
   end
 
+  class Railtie < Rails::Railtie
+    extend Rails::Initializable::ClassMethods
+  end
+
   module Validations : Model
     extend ActiveSupport::Concern
     extend ActiveModel::Validations::ClassMethods

--- a/sig/active_record_compose.rbs
+++ b/sig/active_record_compose.rbs
@@ -76,6 +76,9 @@ module ActiveRecordCompose
     def self.lease_connection: -> ActiveRecord::ConnectionAdapters::AbstractAdapter
     def self.with_connection: [T] () { () -> T } -> T
 
+    def self.filter_attributes: () -> Array[untyped]
+    def self.filter_attributes=: (Array[untyped]) -> untyped
+
     def initialize: (?Hash[attribute_name, untyped]) -> void
     def save: (**untyped options) -> bool
     def save!: (**untyped options) -> untyped
@@ -83,6 +86,9 @@ module ActiveRecordCompose
     def update!: (Hash[attribute_name, untyped]) -> untyped
 
     def id: -> untyped
+
+    def inspect: () -> String
+    def pretty_print: (untyped q) -> void
 
     private
     def models: -> ComposedCollection

--- a/test/active_record_compose/model_inspect_test.rb
+++ b/test/active_record_compose/model_inspect_test.rb
@@ -1,0 +1,166 @@
+# frozen_string_literal: true
+
+require "pp"
+require "stringio"
+require "test_helper"
+require "active_record_compose/model"
+require "active_support/core_ext/time"
+
+class ActiveRecordCompose::ModelInspectTest < ActiveSupport::TestCase
+  test "returns an ActiveRecord model-like #inspect" do
+    klass =
+      Class.new(ActiveRecordCompose::Model) do
+        def self.to_s = "Klass"
+
+        def initialize(account = Account.new)
+          @account = account
+          super()
+          models << account
+        end
+
+        delegate_attribute :name, :email, :created_at, to: :account
+
+        private attr_reader :account
+      end
+
+    account = Account.create!(name: "alice", email: "alice@example.com")
+    model = klass.new(account)
+
+    model.name = "1234567890" * 10
+    model.created_at = Time.new(2025, 1, 2, 3, 4, 5, in: "-0800")
+
+    expected =
+      '#<Klass name: "12345678901234567890123456789012345678901234567890...", email: "alice@example.com", created_at: "2025-01-02 03:04:05.000000000 -0800">'
+    assert { model.inspect == expected }
+
+    assert_pretty_inspect(model, <<~PRETTY_INSPECT)
+      #{Kernel.instance_method(:to_s).bind_call(model).chop}
+       name: "12345678901234567890123456789012345678901234567890...",
+       email: "alice@example.com",
+       created_at: "2025-01-02 03:04:05.000000000 -0800">
+    PRETTY_INSPECT
+  end
+
+  test "The attributes specified in `.filter_attributes` are masked." do
+    klass =
+      Class.new(ActiveRecordCompose::Model) do
+        def self.to_s = "Klass"
+
+        attribute :email, :string
+        attribute :password, :string
+
+        self.filter_attributes += %i[password]
+      end
+    model = klass.new(email: "alice@example.com", password: "Secret")
+
+    assert { model.inspect == '#<Klass email: "alice@example.com", password: [FILTERED]>' }
+
+    assert_pretty_inspect(model, <<~PRETTY_INSPECT)
+      #{Kernel.instance_method(:to_s).bind_call(model).chop}
+       email: "alice@example.com",
+       password: [FILTERED]>
+    PRETTY_INSPECT
+  end
+
+  test "The settings of `.filter_attributes` are valid for sublcass as well." do
+    klass =
+      Class.new(ActiveRecordCompose::Model) do
+        def self.to_s = "Klass"
+
+        attribute :email, :string
+        attribute :password, :string
+
+        self.filter_attributes += %i[password]
+      end
+    subclass =
+      Class.new(klass) do
+        def self.to_s = "Subclass"
+
+        attribute :age, :integer
+      end
+    model = subclass.new(email: "alice@example.com", password: "Secret", age: 25)
+
+    assert { model.inspect == '#<Subclass email: "alice@example.com", password: [FILTERED], age: 25>' }
+
+    assert_pretty_inspect(model, <<~PRETTY_INSPECT)
+      #{Kernel.instance_method(:to_s).bind_call(model).chop}
+       email: "alice@example.com",
+       password: [FILTERED],
+       age: 25>
+    PRETTY_INSPECT
+  end
+
+  test "The `.filter_attributes` settings can be overwritten by sublcass." do
+    klass =
+      Class.new(ActiveRecordCompose::Model) do
+        def self.to_s = "Klass"
+
+        attribute :email, :string
+        attribute :password, :string
+
+        self.filter_attributes += %i[password]
+      end
+    subclass =
+      Class.new(klass) do
+        def self.to_s = "Subclass"
+
+        attribute :age, :integer
+
+        self.filter_attributes += %i[email]
+      end
+    model = subclass.new(email: "alice@example.com", password: "Secret", age: 25)
+
+    assert { model.inspect == "#<Subclass email: [FILTERED], password: [FILTERED], age: 25>" }
+
+    assert_pretty_inspect(model, <<~PRETTY_INSPECT)
+      #{Kernel.instance_method(:to_s).bind_call(model).chop}
+       email: [FILTERED],
+       password: [FILTERED],
+       age: 25>
+    PRETTY_INSPECT
+  end
+
+  test "The `.filter_attributes` setting can be overwritten to blanks using sublcass." do
+    klass =
+      Class.new(ActiveRecordCompose::Model) do
+        def self.to_s = "Klass"
+
+        attribute :email, :string
+        attribute :password, :string
+
+        self.filter_attributes += %i[password]
+      end
+    subclass =
+      Class.new(klass) do
+        def self.to_s = "Subclass"
+
+        attribute :age, :integer
+
+        self.filter_attributes = []
+      end
+    model = subclass.new(email: "alice@example.com", password: "Secret", age: 25)
+
+    assert { model.inspect == '#<Subclass email: "alice@example.com", password: "Secret", age: 25>' }
+
+    assert_pretty_inspect(model, <<~PRETTY_INSPECT)
+      #{Kernel.instance_method(:to_s).bind_call(model).chop}
+       email: "alice@example.com",
+       password: "Secret",
+       age: 25>
+    PRETTY_INSPECT
+
+    subclass.filter_attributes = %i[age]
+
+    assert { model.inspect == '#<Subclass email: "alice@example.com", password: "Secret", age: [FILTERED]>' }
+  end
+
+  private
+
+  def assert_pretty_inspect(object, expected)
+    out = StringIO.new
+    PP.pp(object, out)
+    actual = out.string
+
+    assert_equal expected, actual
+  end
+end

--- a/test/active_record_compose/railtie_test.rb
+++ b/test/active_record_compose/railtie_test.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "active_record_compose"
+
+class ActiveRecordCompose::RailtieTest < ActiveSupport::TestCase
+  include ActiveSupport::Testing::Isolation
+
+  test "The filter_parameters settings in the rails application are reflected in the filter_attributes" do
+    require "fake_app/application"
+
+    assert_changes -> { ActiveRecordCompose::Model.filter_attributes } do
+      FakeApp.initialize!
+
+      assert { FakeApp.config.filter_parameters.size > 0 }
+      assert { (FakeApp.config.filter_parameters - ActiveRecordCompose::Model.filter_attributes).empty? }
+    end
+  end
+end

--- a/test/fake_app/application.rb
+++ b/test/fake_app/application.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require "active_record/railtie"
+require "active_record_compose/railtie"
+
+class FakeApp < Rails::Application
+  config.secret_key_base = "test_secret_key_base"
+  config.eager_load = false
+  config.root = __dir__
+  config.logger = Logger.new($stdout)
+
+  config.filter_parameters += %i[password sensitive]
+end

--- a/test/fake_app/config/database.yml
+++ b/test/fake_app/config/database.yml
@@ -1,0 +1,4 @@
+---
+development:
+  adapter: sqlite3
+  database: ":memory:"


### PR DESCRIPTION
ActiveRecord-like implements inspect.
This provides an experience that looks like an ActiveRecord model, as shown below.

It also features `filter_attributes`, which allows you to implement filters that behave similarly to activerecord.
When using Rails, the initial value will reflect `config.filter_parameters` via railtie.


```ruby
# app/models/model.rb
class Model < ActiveRecordCompose::Model
  def initialize(user)
    @user = user
    super()
    models << user
  end

  attribute :foo, :date, default: -> { Time.current }
  delegate_attribute :id, :name, :email, :age, :created_at, to: :user

  private

  attr_reader :user
end
```
```ruby
> u = User.first
  User Load (0.3ms)  SELECT "users".* FROM "users" ORDER BY "users"."id" ASC LIMIT 1 /*application='Moetan'*/
=> #<User:0x00007fecac422520 id: 1, name: "foo", email: "[FILTERED]", password: "[FILTERED]", age: "18", created_at: "2025-11-13 04:17:41.068628000 +0000", updated_at: "2025-11-13 04:17:41.068628000 +0000">
> m = Model.new(u)
=> #<Model:0x00007fecac326c48 foo: "2025-11-15", id: 1, name: "foo", email: "[FILTERED]", age: "18", created_at: "2025-11-13 04:17:41.068628000 +0000">

> puts m.pretty_inspect
#<Model:0x00007fecac326c48
 foo: "2025-11-15",
 id: 1,
 name: "foo",
 email: [FILTERED],
 age: "18",
 created_at: "2025-11-13 04:17:41.068628000 +0000">
=> nil
```

Normally it will be displayed in color on the console.


<img width="1080" height="110" alt="image" src="https://github.com/user-attachments/assets/1c2cb5e9-8612-4ee2-89f9-7cc847cd37cb" />
