### PR TITLE
deprecate connection class methods

### DIFF
--- a/lib/active_record_compose/transaction_support.rb
+++ b/lib/active_record_compose/transaction_support.rb
@@ -12,10 +12,27 @@ module ActiveRecordCompose
     end
 
     module ClassMethods
-      delegate :with_connection, :lease_connection, to: :ar_class
+      # steep:ignore:start
 
-      # In ActiveRecord, it is soft deprecated.
-      delegate :connection, to: :ar_class
+      # @deprecated
+      def with_connection(...)
+        ActiveRecord.deprecator.warn("`with_connection` is deprecated. Use `ActiveRecord::Base.with_connection` instead.")
+        ActiveRecord::Base.with_connection(...)
+      end
+
+      # @deprecated
+      def lease_connection(...)
+        ActiveRecord.deprecator.warn("`lease_connection` is deprecated. Use `ActiveRecord::Base.lease_connection` instead.")
+        ActiveRecord::Base.lease_connection(...)
+      end
+
+      # @deprecated
+      def connection(...)
+        ActiveRecord.deprecator.warn("`connection` is deprecated. Use `ActiveRecord::Base.connection` instead.")
+        ActiveRecord::Base.connection(...)
+      end
+
+      # steep:ignore:end
 
       def before_commit(*args, &block)
         set_options_for_callbacks!(args)
@@ -33,8 +50,6 @@ module ActiveRecordCompose
       end
 
       private
-
-      def ar_class = ActiveRecord::Base
 
       def prepend_option
         if ActiveRecord.run_after_transaction_callbacks_in_order_defined # steep:ignore

--- a/sig/_internal/package_private.rbs
+++ b/sig/_internal/package_private.rbs
@@ -130,16 +130,11 @@ module ActiveRecordCompose
     module ClassMethods
       include ActiveSupport::Callbacks::ClassMethods
 
-      def connection: -> ActiveRecord::ConnectionAdapters::AbstractAdapter
-      def lease_connection: -> ActiveRecord::ConnectionAdapters::AbstractAdapter
-      def with_connection: [T] () { (ActiveRecord::ConnectionAdapters::AbstractAdapter) -> T } -> T
-
       def before_commit: (*untyped) -> untyped
       def after_commit: (*untyped) -> untyped
       def after_rollback: (*untyped) -> untyped
 
       private
-      def ar_class: -> singleton(ActiveRecord::Base)
       def prepend_option: -> ({ prepend: true } | {})
       def set_options_for_callbacks!: (untyped, ?({ prepend: true } | {})) -> untyped
     end

--- a/sig/active_record_compose.rbs
+++ b/sig/active_record_compose.rbs
@@ -72,9 +72,6 @@ module ActiveRecordCompose
     def self.after_rollback: (*callback[instance], ?if: condition[instance], ?unless: condition[instance], **untyped) ?{ () [self: instance] -> void } -> void
 
     def self.delegate_attribute: (*untyped methods, to: untyped, ?allow_nil: bool) -> untyped
-    def self.connection: -> ActiveRecord::ConnectionAdapters::AbstractAdapter
-    def self.lease_connection: -> ActiveRecord::ConnectionAdapters::AbstractAdapter
-    def self.with_connection: [T] () { () -> T } -> T
 
     def self.filter_attributes: () -> Array[untyped]
     def self.filter_attributes=: (Array[untyped]) -> untyped


### PR DESCRIPTION
deprecates `with_connection`, etc.

Until now, these operations have been implemented simply by delegating to functions such as `ActiveRecord::Base.with_connection`.
However, it is desirable to eliminate dependency on connection-related operations as much as possible.

This is because connection-related operations in ActiveRecordCompose::Model are inherently the property of the models themselves and should be performed by those functions.

Furthermore, this could become a barrier when ActiveRecordCompose::Model implements transaction operations across multiple databases in the future.