### PR TITLE
Transaction callbacks are executed only if all current transactions have finished.

### DIFF
--- a/sig/_internal/package_private.rbs
+++ b/sig/_internal/package_private.rbs
@@ -114,6 +114,8 @@ module ActiveRecordCompose
     include ActiveSupport::Callbacks
     extend ActiveSupport::Callbacks::ClassMethods
 
+    @current_transactions: Set[ActiveRecord::ConnectionAdapters::Transaction]
+
     def self.before_commit: (*untyped) -> untyped
     def self.after_commit: (*untyped) -> untyped
     def self.after_rollback: (*untyped) -> untyped
@@ -128,6 +130,7 @@ module ActiveRecordCompose
     def default_ar_class: -> singleton(ActiveRecord::Base)
     def connection_pool: (?ar_class: singleton(ActiveRecord::Base)) -> ActiveRecord::ConnectionAdapters::ConnectionPool
     def with_pool_transaction_isolation_level: [T] (ActiveRecord::ConnectionAdapters::AbstractAdapter) { () -> T } -> T
+    def current_transactions: () -> Set[ActiveRecord::ConnectionAdapters::Transaction]
   end
 
   module Persistence


### PR DESCRIPTION
refs #47

This is a reorganization aimed at supporting transactions involving multiple databases.

The after commit and after rollback firing conditions have been expanded to include **all transactions being processed must be closed.**

This adjustment delays callback execution until the last transaction has finished, even when multiple transactions are being processed.