### PR TITLE
Fixed an issue where the save method would return nil instead of false.

### DIFF
--- a/lib/active_record_compose/transaction_support.rb
+++ b/lib/active_record_compose/transaction_support.rb
@@ -96,7 +96,7 @@ module ActiveRecordCompose
             connection.add_transaction_record(self, ensure_finalize || has_transactional_callbacks?) # steep:ignore
 
             yield.tap { raise ActiveRecord::Rollback unless _1 }
-          end
+          end || false
         end
       end
     end

--- a/test/active_record_compose/model_test.rb
+++ b/test/active_record_compose/model_test.rb
@@ -44,7 +44,7 @@ class ActiveRecordCompose::ModelTest < ActiveSupport::TestCase
     model = ComposedModel.new
     model.assign_attributes(invalid_attributes)
 
-    assert_not model.save
+    assert { model.save == false }
     e = assert_raises(ActiveRecord::RecordInvalid) { model.save! }
     assert { model == e.record }
   end
@@ -53,7 +53,7 @@ class ActiveRecordCompose::ModelTest < ActiveSupport::TestCase
     model = ComposedModel.new
     model.assign_attributes(valid_attributes)
 
-    assert model.valid?
+    assert { model.valid? == true }
     assert_difference -> { Account.count } => 1, -> { Profile.count } => 1 do
       model.save!
     end
@@ -67,8 +67,8 @@ class ActiveRecordCompose::ModelTest < ActiveSupport::TestCase
     model.assign_attributes(valid_attributes)
     model.push_falsy_object_to_models
 
-    assert model.valid?
-    assert model.save
+    assert { model.valid? == true }
+    assert { model.save == true }
   end
 
   test "errors made during internal model storage are propagated externally." do
@@ -90,7 +90,7 @@ class ActiveRecordCompose::ModelTest < ActiveSupport::TestCase
     model = model_class.new
     model.assign_attributes(valid_attributes)
 
-    assert_not model.save
+    assert { model.save == false }
     assert_raises(ActiveRecord::RecordInvalid) do
       model.save!
     end


### PR DESCRIPTION
When executing save, there are cases where nil is returned instead of false if the operation fails.

In normal use, this rarely has any adverse effects, but it is preferable for false to be returned.

----

example.

```ruby
class Foo < ApplicationRecord
  validate :always_invalid

  private

  def always_invalid
    errors.add(:base, :invalid)
  end
end

class Model < ActiveRecordCompose::Model
  def initialize
    super()
    models << foo
  end

  private

  def foo
    @foo ||= Foo.new
  end
end
```

```ruby
model = Model.new
model.save  #=> nil  (Returns nil instead of false)
```

