### PR TITLE
Change the internal container of ComposedCollection from Array to Set.

### DIFF
--- a/lib/active_record_compose/composed_collection.rb
+++ b/lib/active_record_compose/composed_collection.rb
@@ -13,7 +13,7 @@ module ActiveRecordCompose
 
     def initialize(owner)
       @owner = owner
-      @models = []
+      @models = Set.new
     end
 
     # Enumerates model objects.

--- a/lib/active_record_compose/composed_collection.rb
+++ b/lib/active_record_compose/composed_collection.rb
@@ -69,13 +69,28 @@ module ActiveRecordCompose
     # Removes the specified model from the collection.
     # Returns nil if the deletion fails, self if it succeeds.
     #
+    # The specified model instance will be deleted regardless of the options used when it was added.
+    #
+    # @example
+    #   model_a = Model.new
+    #   model_b = Model.new
+    #
+    #   collection.push(model_a, destroy: true)
+    #   collection.push(model_b)
+    #   collection.push(model_a, destroy: false)
+    #   collection.count  #=> 3
+    #
+    #   collection.delete(model_a)
+    #   collection.count  #=> 1
+    #
     # @param model [Object] model instance
     # @return [self] Successful deletion
     # @return [nil] If deletion fails
     def delete(model)
-      wrapped = wrap(model)
-      return nil unless models.delete(wrapped)
+      matched = models.select { _1.__raw_model == model }
+      return nil if matched.blank?
 
+      matched.each { models.delete(_1) }
       self
     end
 

--- a/lib/active_record_compose/wrapped_model.rb
+++ b/lib/active_record_compose/wrapped_model.rb
@@ -121,7 +121,7 @@ module ActiveRecordCompose
 
     protected
 
-    def equality_key = [ model ]
+    def equality_key = [ model, destroy_context_type, if_option ]
 
     private
 

--- a/sig/_internal/package_private.rbs
+++ b/sig/_internal/package_private.rbs
@@ -68,15 +68,15 @@ module ActiveRecordCompose
 
     private
     attr_reader owner: Model
-    attr_reader models: Array[WrappedModel]
+    attr_reader models: Set[WrappedModel]
     def wrap: (ar_like, ?destroy: (bool | Symbol | destroy_context_type), ?if: (nil | Symbol | condition_type)) -> WrappedModel
     def symbol_proc_map: () -> Hash[Symbol, (destroy_context_type | condition_type)]
 
     module PackagePrivate
-      def __wrapped_models: () -> Array[WrappedModel]
+      def __wrapped_models: () -> Enumerable[WrappedModel]
 
       private
-      def models: () -> Array[WrappedModel]
+      def models: () -> Set[WrappedModel]
     end
 
     include PackagePrivate

--- a/sig/_internal/package_private.rbs
+++ b/sig/_internal/package_private.rbs
@@ -190,7 +190,7 @@ module ActiveRecordCompose
     attr_reader model: ar_like
     attr_reader destroy_context_type: (bool | destroy_context_type)
     attr_reader if_option: (nil | condition_type)
-    def equality_key: () -> [ar_like]
+    def equality_key: () -> [ar_like, (bool | destroy_context_type), (nil | condition_type)]
 
     module PackagePrivate
       def __raw_model: () -> ar_like

--- a/test/active_record_compose/composed_collection_test.rb
+++ b/test/active_record_compose/composed_collection_test.rb
@@ -34,4 +34,21 @@ class ActiveRecordCompose::ComposedCollectionTest < ActiveSupport::TestCase
 
     assert { collection.first == profile }
   end
+
+  test "#delete will delete the specified model regardless of the options used when adding it" do
+    collection = ActiveRecordCompose::ComposedCollection.new(nil)
+    account = Account.new
+    profile = Profile.new
+    collection.push(account, destroy: false)
+    collection.push(profile)
+    collection.push(account, destroy: true)
+
+    assert { collection.first == account }
+    assert { collection.count == 3 }
+
+    collection.delete(account)
+
+    assert { collection.first == profile }
+    assert { collection.count == 1 }
+  end
 end

--- a/test/active_record_compose/wrapped_model_test.rb
+++ b/test/active_record_compose/wrapped_model_test.rb
@@ -9,22 +9,34 @@ class ActiveRecordCompose::WrappedModelTest < ActiveSupport::TestCase
     profile = Profile.new
     wrapped_model = ActiveRecordCompose::WrappedModel.new(account)
 
-    assert { wrapped_model != ActiveRecordCompose::WrappedModel.new(profile) }
-    assert { wrapped_model == ActiveRecordCompose::WrappedModel.new(account) }
+    assert { wrapped_model != described_class.new(profile) }
+    assert { wrapped_model == described_class.new(account) }
   end
 
-  test "the states of other elements are not taken into account" do
+  test "the :destroy option is also taken into account to determine equivalence" do
     account = Account.new
-    wrapped_model = ActiveRecordCompose::WrappedModel.new(account)
 
-    assert { wrapped_model == ActiveRecordCompose::WrappedModel.new(account, destroy: true) }
-    assert { wrapped_model == ActiveRecordCompose::WrappedModel.new(account, destroy: false) }
-    assert { wrapped_model == ActiveRecordCompose::WrappedModel.new(account, if: -> { false }) }
+    assert { described_class.new(account) == described_class.new(account, destroy: false) }
+    assert { described_class.new(account) != described_class.new(account, destroy: true) }
+
+    destroy_proc = -> { true }
+    other_destroy_proc = -> { true }
+    assert { described_class.new(account, destroy: destroy_proc) == described_class.new(account, destroy: destroy_proc) }
+    assert { described_class.new(account, destroy: destroy_proc) != described_class.new(account, destroy: other_destroy_proc) }
+  end
+
+  test "the :if option is also taken into account to determine equivalence" do
+    account = Account.new
+
+    if_proc = -> { true }
+    other_if_proc = -> { true }
+    assert { described_class.new(account, if: if_proc) == described_class.new(account, if: if_proc) }
+    assert { described_class.new(account, if: if_proc) != described_class.new(account, if: other_if_proc) }
   end
 
   test "when `destroy` option is false, save model by `#save`" do
     already_persisted_account = Account.create(name: "foo", email: "foo@example.com")
-    wrapped_model = ActiveRecordCompose::WrappedModel.new(already_persisted_account, destroy: false)
+    wrapped_model = described_class.new(already_persisted_account, destroy: false)
 
     assert wrapped_model.save
     assert already_persisted_account.persisted?
@@ -32,9 +44,13 @@ class ActiveRecordCompose::WrappedModelTest < ActiveSupport::TestCase
 
   test "when `destroy` option is true, delete model by `#save`" do
     already_persisted_account = Account.create(name: "foo", email: "foo@example.com")
-    wrapped_model = ActiveRecordCompose::WrappedModel.new(already_persisted_account, destroy: true)
+    wrapped_model = described_class.new(already_persisted_account, destroy: true)
 
     assert wrapped_model.save
     assert already_persisted_account.destroyed?
   end
+
+  private
+
+  def described_class = ActiveRecordCompose::WrappedModel
 end


### PR DESCRIPTION
refs #49

As mentioned earlier, #56 prevented multiple save commands from being issued for the same object.

Since storing multiple objects with the exact same configuration is redundant, the objects are stored in a Set rather than an Array.

Also, when simultaneously removing models specified with ComposedCollection#delete, if there are multiple matching targets, all of them will be removed.
This is because it would be difficult to specify conditions that match all options.