### PR TITLE
Detect circular references and prevent infinite loops

### DIFF
--- a/lib/active_record_compose.rb
+++ b/lib/active_record_compose.rb
@@ -3,6 +3,7 @@
 require "active_record"
 
 require_relative "active_record_compose/version"
+require_relative "active_record_compose/exceptions"
 require_relative "active_record_compose/model"
 
 # namespaces in gem `active_record_compose`.

--- a/lib/active_record_compose/exceptions.rb
+++ b/lib/active_record_compose/exceptions.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module ActiveRecordCompose
+  # Occurs when a circular reference is detected in the containing model.
+  #
+  # @example
+  #     class Model < ActiveRecordCompose::Model
+  #       def initialize
+  #         super()
+  #         models << self  # Adding itself to models creates a circular reference.
+  #       end
+  #     end
+  #     model = Model.new
+  #     model.save  #=> raises ActiveRecordCompose::CircularReferenceDetected
+  #
+  # @example
+  #     class Model < ActiveRecordCompose::Model
+  #       attribute :model
+  #       before_validation { models << model }
+  #     end
+  #     inner = Model.new
+  #     middle = Model.new(model: inner)
+  #     outer = Model.new(model: middle)
+  #
+  #     inner.model = outer  # There is a circular reference in the form outer > middle > inner > outer.
+  #     outer.save  #=> raises ActiveRecordCompose::CircularReferenceDetected
+  #
+  class CircularReferenceDetected < StandardError; end
+end

--- a/lib/active_record_compose/validations.rb
+++ b/lib/active_record_compose/validations.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative "composed_collection"
+require_relative "validations/circular_reference_detection"
 
 module ActiveRecordCompose
   using ComposedCollection::PackagePrivate
@@ -8,6 +9,9 @@ module ActiveRecordCompose
   module Validations
     extend ActiveSupport::Concern
     include ActiveModel::Validations::Callbacks
+
+    include ActiveRecordCompose::Validations::CircularReferenceDetection # steep:ignore
+    using ActiveRecordCompose::Validations::CircularReferenceDetection # steep:ignore
 
     included do
       validate :validate_models
@@ -80,6 +84,8 @@ module ActiveRecordCompose
 
     # @private
     def validate_models
+      detect_circular_reference # steep:ignore
+
       context = override_validation_context
       models.__wrapped_models.lazy.select { _1.invalid?(context) }.each { errors.merge!(_1) }
     end

--- a/lib/active_record_compose/validations/circular_reference_detection.rb
+++ b/lib/active_record_compose/validations/circular_reference_detection.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+# steep:ignore:start
+# @private
+module ActiveRecordCompose
+  module Validations
+    module CircularReferenceDetection
+      refine self do
+        def detect_circular_reference(targets = [])
+          raise CircularReferenceDetected if targets.include?(object_id)
+
+          targets += [ object_id ]
+          models.select { _1.is_a?(CircularReferenceDetection) }.each do |m|
+            m.detect_circular_reference(targets)
+          end
+        end
+      end
+    end
+  end
+end
+# steep:ignore:end

--- a/sig/active_record_compose.rbs
+++ b/sig/active_record_compose.rbs
@@ -47,6 +47,9 @@ module ActiveRecordCompose
     def delete: (ar_like) -> ComposedCollection?
   end
 
+  class CircularReferenceDetected < StandardError
+  end
+
   class Model
     include ActiveModel::Model
     include ActiveModel::Validations::Callbacks

--- a/test/active_record_compose/circular_reference_detection_test.rb
+++ b/test/active_record_compose/circular_reference_detection_test.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class CircularReferenceDetectionTest < ActiveSupport::TestCase
+  test "cannot add self to models" do
+    m1 = klass.new
+
+    m1.model = m1
+    assert_raises(ActiveRecordCompose::CircularReferenceDetected) do
+      assert { m1.save }
+    end
+  end
+
+  test "there must be no circular references from objects contained in models" do
+    inner = klass.new
+    middle = klass.new(model: inner)
+    outer = klass.new(model: middle)
+
+    inner.model = outer
+
+    assert_raises(ActiveRecordCompose::CircularReferenceDetected) do
+      assert { outer.save }
+    end
+  end
+
+  test "if the objects in the model do not have circular references, no exceptions will occur." do
+    inner = klass.new
+    middle = klass.new(model: inner)
+    outer = klass.new(model: middle)
+
+    assert { outer.save }
+  end
+
+  test "The circular reference detection method #detect_circular_reference is not externally accessible." do
+    model = klass.new
+
+    refute { model.respond_to?(:detect_circular_reference, true) }
+    assert_raises(NoMethodError) { model.detect_circular_reference }
+  end
+
+  private
+
+  def klass
+    @klass ||=
+      Class.new(ActiveRecordCompose::Model) do
+        attribute :model
+        before_validation { models << model }
+      end
+  end
+end


### PR DESCRIPTION
ActiveModelCompose::Model issues a save command in bulk by adding any model object to the models collection.

Models added to the models collection are assumed to have the ActiveModel interface, such as ActiveRecord models, but this includes ActiveModelCompose::Model itself.

Thus, while it is possible to add another ActiveModelCompose::Model to the collection, if there is a circular reference there, a recursive, infinite loop will occur during the save process.

This code detects such circular references and raises an exception.
You should rarely encounter this in normal use.

```ruby
class Model < ActiveRecordCompose::Model
  attribute :model
  before_validation { models << model }
end
inner = Model.new
middle = Model.new(model: inner)
outer = Model.new(model: middle)

inner.model = outer
outer.save  #=> raises ActiveRecordCompose::CircularReferenceDetected
```
