### PR TITLE
Correct usage of assert raises 

### DIFF
--- a/lib/active_record_compose/validations.rb
+++ b/lib/active_record_compose/validations.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative "composed_collection"
+require_relative "exceptions"
 
 module ActiveRecordCompose
   using ComposedCollection::PackagePrivate

--- a/test/active_record_compose/delegate_attribute_test.rb
+++ b/test/active_record_compose/delegate_attribute_test.rb
@@ -73,15 +73,17 @@ class ActiveRecordCompose::DelegateAttributeTest < ActiveSupport::TestCase
   end
 
   test "Raises ArgumentError if instance variable is directly specified in :to option of delegate_attribute" do
-    assert_raises(ArgumentError, "Instance variables cannot be specified in delegate to. (@model)") do
-      Class.new(ActiveRecordCompose::Model) do
-        def initialize(attributes)
-          @model = Inner.new
-          super(attributes)
-        end
+    e =
+      assert_raises(ArgumentError) do
+        Class.new(ActiveRecordCompose::Model) do
+          def initialize(attributes)
+            @model = Inner.new
+            super(attributes)
+          end
 
-        delegate_attribute :x, :y, to: :@model
+          delegate_attribute :x, :y, to: :@model
+        end
       end
-    end
+    assert { e.message == "Instance variables cannot be specified in delegate to. (@model)" }
   end
 end

--- a/test/active_record_compose/model_test.rb
+++ b/test/active_record_compose/model_test.rb
@@ -78,8 +78,10 @@ class ActiveRecordCompose::ModelTest < ActiveSupport::TestCase
     model = ComposedModel.new(account_with_bang.new)
     model.assign_attributes(valid_attributes)
 
-    assert_raises(RuntimeError, "bang!!") { model.save }
-    assert_raises(RuntimeError, "bang!!") { model.save! }
+    e = assert_raises(RuntimeError) { model.save }
+    assert { e.message == "bang!" }
+    e = assert_raises(RuntimeError) { model.save! }
+    assert { e.message == "bang!" }
   end
 
   test "RecordInvalid errors that occur during internal saving of the model are propagated externally only if #save!" do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -5,6 +5,8 @@ Minitest::Reporters.use!
 
 require "minitest/power_assert"
 
+require "debug"
+
 require "i18n"
 I18n.load_path += Dir[File.join(__dir__, "config/locales/*.yml")]
 


### PR DESCRIPTION
The second argument to `assert_raises` does not validate the error message of the exception that is raised.

You must directly check the exception object returned by `assert_raises` to validate the error message.