### PR TITLE
Improved clarity of error when accessing uninitialized attributes

### DIFF
--- a/lib/active_record_compose/exceptions.rb
+++ b/lib/active_record_compose/exceptions.rb
@@ -26,4 +26,19 @@ module ActiveRecordCompose
   #     outer.save  #=> raises ActiveRecordCompose::CircularReferenceDetected
   #
   class CircularReferenceDetected < StandardError; end
+
+  # Occurs when accessing Attributes without initializing it.
+  #
+  # @example
+  #     class Model < ActiveRecordCompose::Model
+  #       def initialize
+  #         # Intentionally not calling super...
+  #       end
+  #
+  #       attribute :foo
+  #     end
+  #     model = Model.new
+  #     model.foo = 1  #=> raises ActiveRecordCompose::UninitializedAttribute
+  #
+  class UninitializedAttribute < StandardError; end
 end

--- a/sig/_internal/package_private.rbs
+++ b/sig/_internal/package_private.rbs
@@ -11,6 +11,9 @@ module ActiveRecordCompose
 
     @attributes: untyped
 
+    private
+    def _require_attributes_initialized: [T] () { () -> T } -> T
+
     class AttributePredicate
       def initialize: (untyped value) -> void
       def call: -> bool

--- a/sig/active_record_compose.rbs
+++ b/sig/active_record_compose.rbs
@@ -98,4 +98,7 @@ module ActiveRecordCompose
   class Railtie < Rails::Railtie
     extend Rails::Initializable::ClassMethods
   end
+
+  class UninitializedAttribute < StandardError
+  end
 end

--- a/test/active_record_compose/model_attribute_test.rb
+++ b/test/active_record_compose/model_attribute_test.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ActiveRecordCompose::ModelAttributeTest < ActiveSupport::TestCase
+  test "If you don't call super in initialize, the attributes won't be accessible because they won't be initialized." do
+    klass =
+      Class.new(ActiveRecordCompose::Model) do
+        def initialize
+          @account = Account.new(name: "Alice", email: "alice@example.com")
+          models << account
+        end
+
+        attribute :confirmation, :boolean, default: false
+        validates :confirmation, presence: true
+
+        private
+
+        attr_reader :account
+      end
+    model = klass.new
+
+    e =
+      assert_raises(ActiveRecordCompose::UninitializedAttribute) do
+        model.confirmation = true
+      end
+    assert { e.message == "No attributes have been set. Is proper initialization performed, such as calling `super` in `initialize`?" }
+  end
+
+  test "Inspect works even if attributes are not initialized" do
+    klass =
+      Class.new(ActiveRecordCompose::Model) do
+        def self.to_s = "Klass"
+
+        def initialize
+        end
+
+        attribute :confirmation, :boolean, default: false
+      end
+    model = klass.new
+
+    assert { model.inspect == "#<Klass not initialized>" }
+  end
+
+  test "If you call super during initialization, the attribute will be initialized and you will be able to access it." do
+    klass =
+      Class.new(ActiveRecordCompose::Model) do
+        def initialize
+          @account = Account.new(name: "Alice", email: "alice@example.com")
+          models << account
+          super()
+        end
+
+        attribute :confirmation, :boolean, default: false
+        validates :confirmation, presence: true
+
+        private
+
+        attr_reader :account
+      end
+    model = klass.new
+
+    assert_difference -> { Account.count } => 1 do
+      model.confirmation = true
+      model.save!
+    end
+  end
+end


### PR DESCRIPTION
When overriding initialize, `@attributes` will not be initialized unless `super` is called, and attributes cannot be accessed.

The behavior depends on `ActiveModel::Attributes`, but the result might look something like this:
```ruby
class Model < ActiveRecordCompose::Model
  def initialize
    # Intentionally not calling super...
  end
  attribute :foo
end

model = Model.new
model.foo = 1 # raises undefined method 'write_from_user' for nil (NoMethodError)
```

This error occurs because `write_from_user` is called on `@attributes`, which is `nil`, resulting in `nil.write_from_user`.

However, this message lacks information about how to fix the model definition.

So, let's define a dedicated error that indicates what to do about errors that occur in such cases.