### PR TITLE
Require `active_support` before `active_support/test_case`

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -10,6 +10,8 @@ require "debug"
 require "i18n"
 I18n.load_path += Dir[File.join(__dir__, "config/locales/*.yml")]
 
+require "active_support"
+
 # Since Rails 7.1, test_case implicitly depends on deprecator.
 require "active_support/deprecator"
 


### PR DESCRIPTION
## Summary

Require `active_support` before loading other Active Support components in the test setup.

Recent changes on Rails HEAD introduced a dependency on `ActiveSupport::Ractors` while loading `active_support/time_formats.rb`.

Since `ActiveSupport::Ractors` is registered via `autoload` in `active_support.rb`, explicitly requiring `active_support` first ensures the constant is available before other Active Support components are loaded.

This keeps the test suite compatible with Rails HEAD.