### PR TITLE
Support secondary and multiple database

### DIFF
--- a/lib/active_record_compose/transaction_support.rb
+++ b/lib/active_record_compose/transaction_support.rb
@@ -106,23 +106,44 @@ module ActiveRecordCompose
 
     def save!(**options) = with_transaction_returning_status { super }
 
+    # @private
+    def connection_pools
+      pools =
+        models.compact.flat_map do |model|
+          if model.is_a?(ActiveRecordCompose::TransactionSupport)
+            model.connection_pools
+          elsif model.is_a?(ActiveRecord::Base)
+            connection_pool(ar_class: model.class)
+          else
+            [] # : Array[ActiveRecord::ConnectionAdapters::ConnectionPool]
+          end
+        end
+      pools << connection_pool if pools.blank?
+      pools.uniq
+    end
+
     private
 
     # @private
-    def with_transaction_returning_status
-      connection_pool.with_connection do |connection|
-        with_pool_transaction_isolation_level(connection) do
-          ensure_finalize = !connection.transaction_open?
+    def with_transaction_returning_status(&block)
+      procs = connection_pools.inject(block) do |inner_proc, pool|
+        -> do
+          pool.with_connection do |connection|
+            with_pool_transaction_isolation_level(connection) do
+              ensure_finalize = !connection.transaction_open?
 
-          connection.transaction do |tran|
-            tran ||= ActiveTransaction.new(connection.current_transaction) # steep:ignore
-            transaction_coordinator.add_transaction(tran)
-            connection.add_transaction_record(self, ensure_finalize || has_transactional_callbacks?)
+              connection.transaction do |tran|
+                tran ||= ActiveTransaction.new(connection.current_transaction) # steep:ignore
+                transaction_coordinator.add_transaction(tran)
+                connection.add_transaction_record(self, ensure_finalize || has_transactional_callbacks?)
 
-            yield.tap { raise ActiveRecord::Rollback unless _1 }
-          end || false
+                inner_proc.call.tap { raise ActiveRecord::Rollback unless _1 }
+              end
+            end
+          end
         end
       end
+      procs.call || false
     end
 
     # @private

--- a/lib/active_record_compose/transaction_support.rb
+++ b/lib/active_record_compose/transaction_support.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require "active_support/core_ext/module"
+require_relative "transaction_support/active_transaction"
+require_relative "transaction_support/transaction_coordinator"
 
 module ActiveRecordCompose
   module TransactionSupport
@@ -86,17 +88,17 @@ module ActiveRecordCompose
 
       # @private
       def before_committed!
-        _run_before_commit_callbacks
+        transaction_coordinator.on_before_comitted { _run_before_commit_callbacks }
       end
 
       # @private
       def committed!(should_run_callbacks: true)
-        _run_commit_callbacks if should_run_callbacks
+        transaction_coordinator.on_after_transaction { _run_commit_callbacks if should_run_callbacks }
       end
 
       # @private
       def rolledback!(force_restore_state: false, should_run_callbacks: true)
-        _run_rollback_callbacks if should_run_callbacks
+        transaction_coordinator.on_after_transaction { _run_rollback_callbacks if should_run_callbacks }
       end
     end
 
@@ -112,7 +114,9 @@ module ActiveRecordCompose
         with_pool_transaction_isolation_level(connection) do
           ensure_finalize = !connection.transaction_open?
 
-          connection.transaction do
+          connection.transaction do |tran|
+            tran ||= ActiveTransaction.new(connection.current_transaction) # steep:ignore
+            transaction_coordinator.add_transaction(tran)
             connection.add_transaction_record(self, ensure_finalize || has_transactional_callbacks?)
 
             yield.tap { raise ActiveRecord::Rollback unless _1 }
@@ -120,6 +124,9 @@ module ActiveRecordCompose
         end
       end
     end
+
+    # @private
+    def transaction_coordinator = @transaction_coordinator ||= TransactionCoordinator.new
 
     # @private
     def default_ar_class = ActiveRecord::Base

--- a/lib/active_record_compose/transaction_support/active_transaction.rb
+++ b/lib/active_record_compose/transaction_support/active_transaction.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module ActiveRecordCompose
+  module TransactionSupport
+    # @private
+    # steep:ignore:start
+
+    # In older versions, the ActiveRecord::Transaction object is not passed to the block argument of #transaction.
+    # So instead, we define a transaction object that can be evaluated equivalently.
+    # This follow-up will no longer be necessary when support for Rails 7.1 is dropped.
+    #
+    class ActiveTransaction
+      def initialize(transaction)
+        @real_transaction = transaction
+      end
+
+      attr_reader :real_transaction
+
+      def open? = !closed?
+
+      def closed? = real_transaction&.state&.completed?
+
+      def ==(other)
+        return true if equal?(other)
+        return false unless self.class == other.class
+
+        real_transaction == other.real_transaction
+      end
+
+      def eql?(other)
+        return true if equal?(other)
+        return false unless self.class == other.class
+
+        real_transaction.eql?(other.real_transaction)
+      end
+
+      def hash = real_transaction.hash
+    end
+
+    # steep:ignore:end
+  end
+end

--- a/lib/active_record_compose/transaction_support/transaction_coordinator.rb
+++ b/lib/active_record_compose/transaction_support/transaction_coordinator.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "set"
+
+module ActiveRecordCompose
+  module TransactionSupport
+    # @private
+    class TransactionCoordinator
+      def add_transaction(active_transaction)
+        transactions << active_transaction
+      end
+
+      # The before_commit callback is controlled so that
+      # it runs just before the outermost transaction commits,
+      # but not just before any inner transactions commit.
+      #
+      def on_before_comitted
+        return if @_before_committed_called
+
+        yield
+        @_before_committed_called = true
+      end
+
+      # It processes after_commit/after_rollback only immediately
+      # after all transactions are closed.
+      #
+      def on_after_transaction
+        return unless all_finished?
+
+        with_transaction_cleanup { yield }
+      end
+
+      private
+
+      def with_transaction_cleanup
+        yield
+      ensure
+        @_before_committed_called = false
+        transactions.reject! { _1.closed? }
+      end
+
+      def all_finished? = transactions.all? { _1.closed? }
+
+      def transactions = @transactions ||= Set.new
+    end
+  end
+end

--- a/sig/_internal/package_private.rbs
+++ b/sig/_internal/package_private.rbs
@@ -118,6 +118,8 @@ module ActiveRecordCompose
     include ActiveSupport::Callbacks
     extend ActiveSupport::Callbacks::ClassMethods
 
+    @transaction_coordinator: ActiveRecordCompose::TransactionSupport::TransactionCoordinator
+
     def self.before_commit: (*untyped) -> untyped
     def self.after_commit: (*untyped) -> untyped
     def self.after_rollback: (*untyped) -> untyped
@@ -132,6 +134,21 @@ module ActiveRecordCompose
     def default_ar_class: -> singleton(ActiveRecord::Base)
     def connection_pool: (?ar_class: singleton(ActiveRecord::Base)) -> ActiveRecord::ConnectionAdapters::ConnectionPool
     def with_pool_transaction_isolation_level: [T] (ActiveRecord::ConnectionAdapters::AbstractAdapter) { () -> T } -> T
+    def transaction_coordinator: () -> ActiveRecordCompose::TransactionSupport::TransactionCoordinator
+
+    class TransactionCoordinator
+      @_before_committed_called: bool
+      @transactions: Set[ActiveRecord::ConnectionAdapters::Transaction]
+
+      def add_transaction: (ActiveRecord::ConnectionAdapters::Transaction) -> void
+      def on_after_transaction: () { () -> void } -> void
+      def on_before_comitted: () { () -> void } -> void
+
+      private
+      def all_finished?: -> bool
+      def transactions: () -> Set[ActiveRecord::ConnectionAdapters::Transaction]
+      def with_transaction_cleanup: () { () -> void } -> void
+    end
   end
 
   module Persistence

--- a/sig/_internal/package_private.rbs
+++ b/sig/_internal/package_private.rbs
@@ -129,8 +129,10 @@ module ActiveRecordCompose
     def _run_before_commit_callbacks: () -> untyped
     def _run_commit_callbacks: () -> untyped
     def _run_rollback_callbacks: () -> untyped
+    def connection_pools: () -> Array[ActiveRecord::ConnectionAdapters::ConnectionPool]
 
     private
+    def models: -> ComposedCollection
     def default_ar_class: -> singleton(ActiveRecord::Base)
     def connection_pool: (?ar_class: singleton(ActiveRecord::Base)) -> ActiveRecord::ConnectionAdapters::ConnectionPool
     def with_pool_transaction_isolation_level: [T] (ActiveRecord::ConnectionAdapters::AbstractAdapter) { () -> T } -> T

--- a/test/active_record_compose/multiple_database_callback_test.rb
+++ b/test/active_record_compose/multiple_database_callback_test.rb
@@ -1,0 +1,167 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ActiveRecordCompose::MultipleDatabaseCallbackTest < ActiveSupport::TestCase
+  class ComposeModel < ActiveRecordCompose::Model
+    attribute :tracer
+    attribute :tag, :string
+
+    def initialize(*__models, tracer:, **attributes)
+      __models.each { models << _1 }
+      super(tracer:, **attributes)
+    end
+
+    before_commit { tracer << "#{tag}: before_commit called!" }
+    after_commit { tracer << "#{tag}: after_commit called!" }
+    after_rollback { tracer << "#{tag}: after_rollback called!" }
+  end
+
+  test "before_commit and after_commit are called upon commit" do
+    tracer = []
+
+    pri_1 = new_primary_model(tracer:, tag: "p_1")
+    pri_2 = new_primary_model(tracer:, tag: "p_2")
+    model = ComposeModel.new(pri_1, pri_2, tracer:, tag: "__1")
+
+    assert_difference -> { primary_model_class.count } => 2 do
+      model.save!
+    end
+    expected =
+      [
+        "__1: before_commit called!",
+        "p_1: before_commit called!",
+        "p_2: before_commit called!",
+        "__1: after_commit called!",
+        "p_1: after_commit called!",
+        "p_2: after_commit called!"
+      ]
+    assert { tracer == expected }
+  end
+
+  test "before_commit fires just before the first commit operation, and after_commit fires just after the last commit operation." do
+    tracer = []
+
+    pri_1 = new_primary_model(tracer:, tag: "p_1")
+    sec_1 = new_secondary_model(tracer:, tag: "s_1")
+    model = ComposeModel.new(pri_1, sec_1, tracer:, tag: "__1")
+
+    assert_difference -> { primary_model_class.count } => 1 do
+      assert_difference -> { secondary_model_class.count } => 1 do
+        model.save!
+      end
+    end
+    expected =
+      [
+        "__1: before_commit called!",
+        "p_1: before_commit called!",
+        "p_1: after_commit called!",
+        "s_1: before_commit called!",
+        "__1: after_commit called!",
+        "s_1: after_commit called!"
+      ]
+    assert { tracer == expected }
+  end
+
+  test "If there are multiple database connections, after_commit will only be executed once all connections have terminated." do
+    tracer = []
+
+    pri_1 = new_primary_model(tracer:, tag: "p_1")
+    inner_1 = ComposeModel.new(pri_1, tracer:, tag: "__1")
+
+    sec_1 = new_secondary_model(tracer:, tag: "s_1")
+    inner_2 = ComposeModel.new(sec_1, tracer:, tag: "__2")
+
+    model = ComposeModel.new(inner_1, inner_2, tracer:, tag: "__3")
+
+    assert_difference -> { primary_model_class.count } => 1 do
+      assert_difference -> { secondary_model_class.count } => 1 do
+        model.save!
+      end
+    end
+    expected =
+      [
+        "__3: before_commit called!",
+        "__1: before_commit called!",
+        "p_1: before_commit called!",
+        "__1: after_commit called!",
+        "p_1: after_commit called!",
+        "__2: before_commit called!",
+        "s_1: before_commit called!",
+        "__3: after_commit called!",
+        "__2: after_commit called!",
+        "s_1: after_commit called!"
+      ]
+    assert { tracer == expected }
+  end
+
+  test "When executed within an explicit transaction, the callback execution is deferred until the end of the outer transaction." do
+    tracer = []
+
+    pri_1 = new_primary_model(tracer:, tag: "p_1")
+    sec_1 = new_secondary_model(tracer:, tag: "s_1")
+
+    model = ComposeModel.new(pri_1, sec_1, tracer:, tag: "__1")
+
+    assert_difference -> { primary_model_class.count } => 1 do
+      assert_difference -> { secondary_model_class.count } => 1 do
+        ApplicationRecord.transaction do
+          SecondaryRecord.transaction do
+            model.save!
+            tracer << "---: inner transaction"
+          end
+          tracer << "---: secondary outer transaction"
+        end
+        tracer << "---: primary outer transaction"
+      end
+    end
+
+    expected =
+      [
+        "---: inner transaction",
+        "__1: before_commit called!",
+        "s_1: before_commit called!",
+        "s_1: after_commit called!",
+        "---: secondary outer transaction",
+        "p_1: before_commit called!",
+        "__1: after_commit called!",
+        "p_1: after_commit called!",
+        "---: primary outer transaction"
+      ]
+    assert { tracer == expected }
+  end
+
+  private
+
+  def primary_model_class
+    @primary_model_class ||=
+      Class.new(Account) do
+        attribute :tracer
+        attribute :tag, :string
+
+        before_commit { tracer << "#{tag}: before_commit called!" }
+        after_commit { tracer << "#{tag}: after_commit called!" }
+        after_rollback { tracer << "#{tag}: after_rollback called!" }
+      end
+  end
+
+  def secondary_model_class
+    @secondary_model_class ||=
+      Class.new(SecondaryModel) do
+        attribute :tracer
+        attribute :tag, :string
+
+        before_commit { tracer << "#{tag}: before_commit called!" }
+        after_commit { tracer << "#{tag}: after_commit called!" }
+        after_rollback { tracer << "#{tag}: after_rollback called!" }
+      end
+  end
+
+  def new_primary_model(tracer:, tag:)
+    primary_model_class.new(name: "foo", email: "foo@example.com", tracer:, tag:)
+  end
+
+  def new_secondary_model(tracer:, tag:)
+    secondary_model_class.new(tracer:, tag:)
+  end
+end

--- a/test/active_record_compose/multiple_database_test.rb
+++ b/test/active_record_compose/multiple_database_test.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ActiveRecordCompose::MultipleDatabaseTest < ActiveSupport::TestCase
+  PRIMARY_DB_MODEL = Account
+  SECONDARY_DB_MODEL = SecondaryModel
+
+  class ComposeModel < ActiveRecordCompose::Model
+    def initialize(*__models)
+      __models.each { models << _1 }
+      super()
+    end
+
+    attribute :before_commit_calls, :integer, default: 0
+    attribute :after_commit_calls, :integer, default: 0
+    attribute :after_rollback_calls, :integer, default: 0
+
+    before_commit { self.before_commit_calls += 1 }
+    after_commit { self.after_commit_calls += 1 }
+    after_rollback { self.after_rollback_calls += 1 }
+  end
+
+  test "When the save is successful, all connections will be committed." do
+    pri_1 = new_primary_model
+    sec_1 = new_secondary_model
+    sec_2 = new_secondary_model
+    model = ComposeModel.new(pri_1, sec_1, sec_2)
+
+    assert_difference -> { PRIMARY_DB_MODEL.count } => 1 do
+      assert_difference -> { SECONDARY_DB_MODEL.count } => 2 do
+        model.save!
+      end
+    end
+  end
+
+  test "When the save fails, any connections will be rolled back." do
+    pri = new_primary_model.tap { _1.singleton_class.after_save { raise RuntimeError } }
+    sec = new_secondary_model
+    model = ComposeModel.new(pri, sec)
+
+    assert_no_difference -> { PRIMARY_DB_MODEL.count } do
+      assert_no_difference -> { SECONDARY_DB_MODEL.count } do
+        model.save!
+      rescue RuntimeError # do noghing.
+      end
+    end
+
+    pri = new_primary_model
+    sec = new_secondary_model.tap { _1.singleton_class.after_save { raise RuntimeError } }
+    model = ComposeModel.new(pri, sec)
+
+    assert_no_difference -> { PRIMARY_DB_MODEL.count } do
+      assert_no_difference -> { SECONDARY_DB_MODEL.count } do
+        model.save!
+      rescue RuntimeError # do noghing.
+      end
+    end
+  end
+
+  test "When the save is successful, the before_commit and after_commit callbacks will be fired." do
+    pri_1 = new_primary_model
+    sec_1 = new_secondary_model
+    sec_2 = new_secondary_model
+    model = ComposeModel.new(pri_1, sec_1, sec_2)
+
+    model.save!
+
+    assert { model.before_commit_calls == 1 }
+    assert { model.after_commit_calls == 1 }
+    assert { model.after_rollback_calls == 0 }
+  end
+
+  test "When the save fails, the after_rollback callback will be fired." do
+    pri = new_primary_model.tap { _1.singleton_class.after_save { raise RuntimeError } }
+    sec = new_secondary_model
+    model = ComposeModel.new(pri, sec)
+
+    begin
+      model.save!
+    rescue RuntimeError # do noghing.
+    end
+
+    assert { model.before_commit_calls == 0 }
+    assert { model.after_commit_calls == 0 }
+    assert { model.after_rollback_calls == 1 }
+  end
+
+  private
+
+  def new_primary_model = PRIMARY_DB_MODEL.new(name: "foo", email: "foo@example.com")
+
+  def new_secondary_model = SECONDARY_DB_MODEL.new
+end

--- a/test/support/configuration.rb
+++ b/test/support/configuration.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
 ActiveRecord::Base.configurations = {
-  primary: { adapter: "sqlite3", database: ":memory:" }
+  primary: { adapter: "sqlite3", database: ":memory:" },
+  secondary: { adapter: "sqlite3", database: ":memory:" }
 }

--- a/test/support/model.rb
+++ b/test/support/model.rb
@@ -26,3 +26,6 @@ end
 class OperationLog < ApplicationRecord
   validates :action, presence: true
 end
+
+class SecondaryModel < SecondaryRecord
+end

--- a/test/support/schema.rb
+++ b/test/support/schema.rb
@@ -7,6 +7,11 @@ class ApplicationRecord < ActiveRecord::Base
   connects_to database: { writing: :primary }
 end
 
+class SecondaryRecord < ActiveRecord::Base
+  self.abstract_class = true
+  connects_to database: { writing: :secondary }
+end
+
 ApplicationRecord.connection_pool.with_connection do |conn|
   conn.create_table :accounts, force: true do |t|
     t.string :name, null: false
@@ -31,4 +36,8 @@ ApplicationRecord.connection_pool.with_connection do |conn|
   conn.create_table :operation_logs, force: true do |t|
     t.string :action, null: false
   end
+end
+
+SecondaryRecord.connection_pool.with_connection do |conn|
+  conn.create_table :secondary_models, force: true
 end


### PR DESCRIPTION
refs #47

When models connecting to different databases are used together, the system behaves in a manner simulating a two-phase commit.

Due to the nature of the ActiveRecord API supported by Rails, a true two-phase commit is not implemented; instead, transactions are nested when multiple database connections are involved.

Note that operations remain unchanged when all models belong to a single primary database.